### PR TITLE
Fix compile error: Remove duplicate translation lines from po/de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -6468,9 +6468,6 @@ msgstr "QSO Datum"
 #~ msgid "View/Hide Smeter"
 #~ msgstr "Kanäle anzeigen/verbergen"
 
-#~ msgid "FFT latency (scan merging)"
-#~ msgstr "FFT Latenz (scan merging)"
-
 #, fuzzy
 #~ msgid "Use cross-hair scope"
 #~ msgstr "Fadenkreuz verwenden"


### PR DESCRIPTION
Fixes compile on Ubuntu 12.04 64-bit.
